### PR TITLE
Add: string array support

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -70,6 +70,13 @@ if (process.env.GOOGLE_CLIENT_ID) {
   }));
 }
 
+app.options('*', function(req, res) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'x-rm-token, Accept, Content-Type');
+  res.send({'result': 'ok'});
+})
+
 app.get('/auth', function(req, res) {
   res.json({
     strategies: [{
@@ -125,9 +132,17 @@ var specs = {
         email: { type: 'string', style: 'long' },
         phone: 'string',
         createdAt: { type: 'string', format: 'date' },
+        official: {type: 'string', enum: ['true','false']},
+        role: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
       },
       primaryKey: ['userId'],
-      required: ['userId','firstName','lastName']
+      required: ['userId','firstName','lastName'],
+      uneditable: ['role']
     },
     features: {
       list: {
@@ -138,6 +153,8 @@ var specs = {
           { id: 'email', style: { flex: 6 }},
           'phone',
           { id: 'createdAt', format: 'short-date' },
+          'official',
+          'role'
         ]
       },
       download: true,
@@ -234,6 +251,8 @@ app.get('/config', requireAuth, function(req, res) {
         site: {
           title: 'Example App',
         },
+        official: 'isOfficial',
+        role: 'role'
       },
       ja: {
         address: '住所',
@@ -265,6 +284,8 @@ app.get('/config', requireAuth, function(req, res) {
         site: {
           title: 'サンプルアプリ',
         },
+        official: 'オフィシャルユーザー',
+        role: '権限'
       }
     },
 

--- a/example/data.js
+++ b/example/data.js
@@ -12,6 +12,7 @@ var generate = function(generator, size) {
 };
 
 var user = function(i) {
+  var official = i%5 == 0
   return {
     userId: 'user_' + i,
     firstName: faker.name.firstName(),
@@ -25,7 +26,9 @@ var user = function(i) {
       },
       duration: 3600000000
     },
-    createdAt: faker.date.past()
+    createdAt: faker.date.past(),
+    official: String(official),
+    role: [''+i, ''+i*2],
   };
 };
 

--- a/src/js/components/entity/EntityTableRow.jsx
+++ b/src/js/components/entity/EntityTableRow.jsx
@@ -46,8 +46,7 @@ let EntityTableRow = React.createClass({
     let columns = fields.map(field => {
 
       let value = _.get(item, field.id);
-      let isPrimary = spec.isPrimary(field.id);
-      let isEditable = !isPrimary;
+      let isEditable = spec.isEditable(field.id);
 
       return <EntityTableColumn
         ref={field.id}
@@ -93,4 +92,3 @@ let EntityTableRow = React.createClass({
 });
 
 export default EntityTableRow;
-

--- a/src/js/components/forms/SchemaForm.jsx
+++ b/src/js/components/forms/SchemaForm.jsx
@@ -148,6 +148,19 @@ let SchemaForm = React.createClass({
     let value = this.getValue();
     console.info("Submitting schema form", value);
 
+    // support for string array only
+    // not support nested array, object array
+    let arrayFields = _.map(this.props.schema.properties, function(p, key){
+      if (p.type === 'array') return key;
+    });
+
+    value = _.forEach(value, function(v, key) {
+      let has = _.includes(arrayFields, key);
+      if (has && v) value[key] = v.split(',');
+    });
+
+    console.info("Submitting converted schema form", value);
+
     let result = this._validate(value);
     if (result.valid) {
       if (this.props.onSubmit) {
@@ -168,4 +181,3 @@ let SchemaForm = React.createClass({
 });
 
 export default SchemaForm;
-

--- a/src/js/components/forms/SchemaItem.jsx
+++ b/src/js/components/forms/SchemaItem.jsx
@@ -78,7 +78,12 @@ let SchemaItem = React.createClass({
   },
 
   _makeArray() {
-    return <div>NOT YET IMPLEMENTED</div>;
+    if (this.props.schema.items.type === 'string') {
+      let SchemaText = require('./SchemaText.jsx');
+      return <SchemaText {...this.props} onChange={this._didChange} error={this.state.error} ref="item" />;
+    } else {
+      return <div>NOT YET IMPLEMENTED</div>
+    }
   },
 
   _didChange(value) {

--- a/src/js/services/EntitySpec.js
+++ b/src/js/services/EntitySpec.js
@@ -36,6 +36,13 @@ class EntitySpec {
     return this.schema.primaryKey.indexOf(key) >= 0;
   }
 
+  /**
+   * Check the key is editable
+   */
+  isEditable(key) {
+    return this.schema.primaryKey.indexOf(key) < 0 && this.schema.uneditable.indexOf(key) < 0;
+  }
+
 }
 
 export default EntitySpec;


### PR DESCRIPTION
@suguru  please review.

Add array form support (string array only).
It is possible to input array to form with `,` split.

Add control of uneditable in table row , even if it is not the primary key.
because array column is coverted to `string` type in table row editting.
