### PR TITLE
Add: string array support

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -70,6 +70,13 @@ if (process.env.GOOGLE_CLIENT_ID) {
   }));
 }
 
+app.options('*', function(req, res) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'x-rm-token, Accept, Content-Type');
+  res.send({'result': 'ok'});
+})
+
 app.get('/auth', function(req, res) {
   res.json({
     strategies: [{
@@ -125,6 +132,14 @@ var specs = {
         email: { type: 'string', style: 'long' },
         phone: 'string',
         createdAt: { type: 'string', format: 'date' },
+        official: {type: 'string', enum: ['true','false']},
+        role: {
+          type: 'array',
+          disable: true,
+          items: {
+            type: 'string'
+          }
+        }
       },
       primaryKey: ['userId'],
       required: ['userId','firstName','lastName']
@@ -138,6 +153,8 @@ var specs = {
           { id: 'email', style: { flex: 6 }},
           'phone',
           { id: 'createdAt', format: 'short-date' },
+          'official',
+          'role'
         ]
       },
       download: true,
@@ -152,7 +169,10 @@ var specs = {
         companyId: { type: 'string', maxLength: 100, minLength: 1 },
         name: { type: 'string', maxLength: 100, minLength: 1 },
         phrase: 'string',
-        country: 'string',
+        country: {
+          type: 'string',
+          disable: true,
+        },
         address: {
           type: 'object',
           properties: {
@@ -234,6 +254,8 @@ app.get('/config', requireAuth, function(req, res) {
         site: {
           title: 'Example App',
         },
+        official: 'isOfficial',
+        role: 'role'
       },
       ja: {
         address: '住所',
@@ -265,6 +287,8 @@ app.get('/config', requireAuth, function(req, res) {
         site: {
           title: 'サンプルアプリ',
         },
+        official: 'オフィシャルユーザー',
+        role: '権限'
       }
     },
 

--- a/example/data.js
+++ b/example/data.js
@@ -12,6 +12,7 @@ var generate = function(generator, size) {
 };
 
 var user = function(i) {
+  var official = i%5 == 0
   return {
     userId: 'user_' + i,
     firstName: faker.name.firstName(),
@@ -25,7 +26,9 @@ var user = function(i) {
       },
       duration: 3600000000
     },
-    createdAt: faker.date.past()
+    createdAt: faker.date.past(),
+    official: String(official),
+    role: [''+i, ''+i*2],
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^0.13.0",
     "react-list": "^0.3.1",
     "react-router": "^0.13.0",
+    "react-tagsinput": "^1.3.3",
     "react-tap-event-plugin": "^0.1.3",
     "superagent": "^1.1.0",
     "tv4": "^1.1.9",

--- a/src/js/components/entity/EntityTableRow.jsx
+++ b/src/js/components/entity/EntityTableRow.jsx
@@ -46,8 +46,7 @@ let EntityTableRow = React.createClass({
     let columns = fields.map(field => {
 
       let value = _.get(item, field.id);
-      let isPrimary = spec.isPrimary(field.id);
-      let isEditable = !isPrimary;
+      let isEditable = spec.isEditable(field.id);
 
       return <EntityTableColumn
         ref={field.id}
@@ -93,4 +92,3 @@ let EntityTableRow = React.createClass({
 });
 
 export default EntityTableRow;
-

--- a/src/js/components/forms/SchemaArrayText.jsx
+++ b/src/js/components/forms/SchemaArrayText.jsx
@@ -1,0 +1,66 @@
+'use strict';
+
+import React from 'react';
+import i18n from '../../i18n';
+import TagsInput from 'react-tagsinput'
+
+import { TextField } from 'material-ui';
+import { ValidateMixin } from './SchemaMixin';
+
+let SchemaArrayText = React.createClass({
+  displayName: "Texts Component",
+
+  mixins: [ValidateMixin, React.addons.LinkedStateMixin],
+
+  propTypes: {
+    name: React.PropTypes.string,
+    schema: React.PropTypes.object,
+    value: React.PropTypes.array,
+    onChange: React.PropTypes.func,
+    error: React.PropTypes.object,
+  },
+
+  getInitialState() {
+    console.info('init.array', this.props.value);
+    return {
+      tags: this.props.value,
+      errors: this.props.error,
+    };
+  },
+
+  componentWillReceiveProps(props) {
+    this.state.tags = props.value;
+    this.state.error = props.error;
+  },
+
+  getValue() {
+    return this.refs.tags.getTags().join(', ');
+  },
+
+  saveTags() {
+    console.info('tags: ', this.refs.tags.getTags().join(', '));
+  },
+
+  render() {
+
+    let schema = this.props.schema;
+    let error = this.state.error;
+    let cols = schema.cols || 12;
+    let localizedLabel = i18n(this.props.name);
+    let placeholder = 'Add ' + localizedLabel
+
+    return (
+      <div className={"schema-form__item schema-form__item--array cols-"+cols}>
+        <label>{localizedLabel}</label>
+        <TagsInput
+          ref="tags"
+          placeholder={placeholder}
+          valueLink={this.linkState('tags')}
+          onChange={this.saveTags} />
+      </div>
+    );
+  },
+
+});
+
+export default SchemaArrayText;

--- a/src/js/components/forms/SchemaForm.jsx
+++ b/src/js/components/forms/SchemaForm.jsx
@@ -148,6 +148,19 @@ let SchemaForm = React.createClass({
     let value = this.getValue();
     console.info("Submitting schema form", value);
 
+    // support for string array only
+    // not support nested array, object array
+    let arrayFields = _.map(this.props.schema.properties, (p, key) => {
+      if (p.type === 'array') return key;
+    });
+
+    value = _.forEach(value, (v, key) => {
+      let has = _.includes(arrayFields, key);
+      if (has && v) value[key] = v.split(',');
+    });
+
+    console.info("Submitting converted schema form", value);
+
     let result = this._validate(value);
     if (result.valid) {
       if (this.props.onSubmit) {
@@ -168,4 +181,3 @@ let SchemaForm = React.createClass({
 });
 
 export default SchemaForm;
-

--- a/src/js/components/forms/SchemaItem.jsx
+++ b/src/js/components/forms/SchemaItem.jsx
@@ -78,7 +78,12 @@ let SchemaItem = React.createClass({
   },
 
   _makeArray() {
-    return <div>NOT YET IMPLEMENTED</div>;
+    if (this.props.schema.items.type === 'string') {
+      let SchemaArrayText = require('./SchemaArrayText.jsx');
+      return <SchemaArrayText {...this.props} onChange={this._didChange} error={this.state.error} ref="item" />;
+    } else {
+      return <div>NOT YET IMPLEMENTED</div>
+    }
   },
 
   _didChange(value) {

--- a/src/js/services/EntitySpec.js
+++ b/src/js/services/EntitySpec.js
@@ -36,6 +36,17 @@ class EntitySpec {
     return this.schema.primaryKey.indexOf(key) >= 0;
   }
 
+  /**
+   * Check the key is editable
+   */
+  isEditable(key) {
+    let disable = false;
+    if (this.schema.properties[key]) {
+      disable = this.schema.properties[key].disable;
+    }
+    return this.schema.primaryKey.indexOf(key) < 0 && !Boolean(disable);
+  }
+
 }
 
 export default EntitySpec;

--- a/src/styles/schema_form.less
+++ b/src/styles/schema_form.less
@@ -81,5 +81,71 @@
       }
     }
 
+    &--array {
+      position: relative;
+      margin-top: 10px;
+
+      label {
+        line-height: 36px;
+        margin-right: 10px;
+        color: rgba(0,0,0,0.5);
+      }
+    }
+
   }
+}
+
+
+
+/* for react-tagsinput component */
+.react-tagsinput {
+  border: 1px solid #ccc;
+  background: #fff;
+  padding: 10px;
+  overflow-y: auto;
+  border-radius: 3px;
+}
+
+.react-tagsinput-tag {
+  display: block;
+  border: 1px solid #c2dbf8;
+  background: #e1e7f6;
+  color: #5a5a5a;
+  float: left;
+  padding: 5px;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  text-decoration: none;
+  border-radius: 2px;
+}
+
+.react-tagsinput-invalid {
+  background: #FBD8DB !important;
+  color: #90111A !important;
+}
+
+.react-tagsinput-validating {
+  background: #FFFACD !important;
+}
+
+.react-tagsinput-remove {
+  font-weight: bold;
+  color: #5a5a5a;
+  text-decoration: none;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.react-tagsinput-remove:before {
+  content: " x";
+}
+
+.react-tagsinput-input {
+  background: transparent;
+  color: #777;
+  border: 1px solid #eaeaea;
+  padding: 8px;
+  margin: 0 0 0 10px;
+  width: 120px;
+  outline: none;
 }


### PR DESCRIPTION
@suguru please review.
- Add array form support (string array only).
- Add control of uneditable in table row , even if it is not the primary key.  
  Because array column is coverted to string type, when it is edited in table row.
- Implemented using the compnent https://github.com/olahol/react-tagsinput

Related pull request
https://github.com/dogenzaka/react-manager/pull/2
