### PR TITLE
Add: create desktop application by electron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bower_components
 .lock-wscript
 
 env.sh
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Manager
 
-Management console for any services inspired by ng-manager. You can use react manager to your services only with implementing simple REST API.
+Management console for any services inspired by ng-manager.  
+You can use react manager to your services only with implementing simple REST API.
 
 ## Quick start
 
@@ -29,3 +30,49 @@ To build and run example server,
 gulp
 ```
 
+<br/>
+As Desktop Application
+----
+Desktop app is created by [Electron](https://github.com/atom/electron).
+<br/>
+#### Run as Electron App
+for `electron` command.
+```shell
+npm install electron-prebuilt -g
+```
+
+run example server on `http://localhost:4000`
+```shell
+gulp server
+```
+run react-manager as Electron App
+```shell
+electron .
+```
+register endpoint `http://localhost:4000`  
+
+<br/>
+#### Packaging and Distribute
+for all platform (mac, win32, win64)
+```shell
+gulp electron
+```
+for specific platform
+```
+gulp build
+gulp electron_mac
+gulp electron_win32
+gulp electron_win64
+```
+`app_mac.zip` `app_win32.zip` `app_win64.zip` are created in root directory.  
+you can unzip and execute the application.
+```
+unzip app_mac.zip -d app_mac
+// ...logs
+// created react-manager.app
+
+// Let's run!
+cd app_mac
+open -a react-manager.app
+// shutdown is cmd+Q
+```

--- a/gulp/electron.js
+++ b/gulp/electron.js
@@ -1,0 +1,34 @@
+
+var gulp = require('gulp');
+var electron = require('gulp-atom-shell');
+
+gulp.task('electron', ['build', 'electron_mac', 'electron_win32', 'electron_win64']);
+
+gulp.task('electron_mac', function () {
+    return gulp.src('./**')
+        .pipe(electron({
+                  version: '0.26.0',
+                  platform: 'darwin'
+         }))
+        .pipe(electron.zfsdest('app_mac.zip'));
+});
+
+gulp.task('electron_win64', function () {
+    return gulp.src('./**')
+        .pipe(electron({
+                  version: '0.26.0',
+                  platform: 'win32',
+                  arch: "x64"
+         }))
+         .pipe(electron.zfsdest('app_win64.zip'));
+});
+
+gulp.task('electron_win32', function () {
+    return gulp.src('./**')
+        .pipe(electron({
+                  version: '0.26.0',
+                  platform: 'win32',
+                  arch: "ia32"
+         }))
+         .pipe(electron.zfsdest('app_win32.zip'));
+});

--- a/main.js
+++ b/main.js
@@ -1,0 +1,33 @@
+var app = require('app');  // Module to control application life.
+var BrowserWindow = require('browser-window');  // Module to create native browser window.
+
+// Report crashes to our server.
+require('crash-reporter').start();
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the javascript object is GCed.
+var mainWindow = null;
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+  if (process.platform != 'darwin')
+    app.quit();
+});
+
+// This method will be called when atom-shell has done everything
+// initialization and ready for creating browser windows.
+app.on('ready', function() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 1024, height: 768});
+
+  // and load the index.html of the app.
+  mainWindow.loadUrl('file://' + __dirname + '/build/index.html');
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function() {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Extensible management console running on react",
   "author": "dogenzaka.io",
+  "main": "main.js",
   "license": "MIT",
   "dependencies": {
     "animate.css": "^3.2.5",
@@ -26,6 +27,7 @@
     "express": "^4.12.3",
     "faker": "^2.1.2",
     "gulp": "^3.8.7",
+    "gulp-atom-shell": "^0.10.0",
     "gulp-bower": "0.0.10",
     "gulp-concat": "^2.5.2",
     "gulp-connect": "^2.2.0",


### PR DESCRIPTION
@suguru please review.
- Add gulp task: create react-manager's desktop application by Electron.  
  Because [web URL](http://dogenzaka.github.io/react-manager) is public.  
  In most cases, admin's endpoint URL is not able to access without VPN,  
  even so I want to hide the URL..  
